### PR TITLE
Add a temporary meta-runner.

### DIFF
--- a/metarunners/ArtifactoryPushDockerImag.xml
+++ b/metarunners/ArtifactoryPushDockerImag.xml
@@ -1,0 +1,43 @@
+<meta-runner name="Push Artifactory Docker Image">
+    <description>Additional image publisher (temporary)</description>
+    <settings>
+        <parameters>
+            <param name="DOCKER_REGISTRY" value="%DOCKER_REGISTRY%" />
+            <param name="ARTIFACTORY_DOCKER_IMAGE" value="%DISTRIBUTION_DOCKER_IMAGE_NAME%" />
+            <param name="ARTIFACTORY_DOCKER_BUILD_NUMBER" value="%BUILD_VERSION%" />
+            <param name="ARTIFACTORY_DOCKER_REPOSITORY" value="%DOCKER_REPO_DEV%" />
+            <param name="ARTIFACTORY_DOCKER_BUILD_NAME" value="%ARTIFACTORY_DOCKER_BUILD_NAME%" />
+        </parameters>
+        <build-runners>
+            <runner name="Push Image (Docker)" type="simpleRunner">
+                <conditions>
+                    <does-not-equal name="DISTRIBUTION_DOCKER_IMAGE_NAME" value="" />
+                    <equals name="container.engine" value="docker" />
+                </conditions>
+                <parameters>
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource" value="Job configuration" />
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource" value="Job configuration" />
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.useSpecs" value="false" />
+                    <param name="script.content"><![CDATA[jfrog rt docker-push %DOCKER_REGISTRY%/%ARTIFACTORY_DOCKER_IMAGE%:%ARTIFACTORY_DOCKER_BUILD_NUMBER% %ARTIFACTORY_DOCKER_REPOSITORY% --build-name=%ARTIFACTORY_DOCKER_BUILD_NAME% --build-number=%ARTIFACTORY_DOCKER_BUILD_NUMBER%]]></param>
+                    <param name="teamcity.step.mode" value="default" />
+                    <param name="use.custom.script" value="true" />
+                </parameters>
+            </runner>
+            <runner name="Push Image (Podman)" type="simpleRunner">
+                <conditions>
+                    <does-not-equal name="DISTRIBUTION_DOCKER_IMAGE_NAME" value="" />
+                    <equals name="container.engine" value="podman" />
+                </conditions>
+                <parameters>
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource" value="Job configuration" />
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource" value="Job configuration" />
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.useSpecs" value="false" />
+                    <param name="script.content"><![CDATA[jfrog rt podman-push %DOCKER_REGISTRY%/%ARTIFACTORY_DOCKER_IMAGE%:%ARTIFACTORY_DOCKER_BUILD_NUMBER% %ARTIFACTORY_DOCKER_REPOSITORY% --build-name=%ARTIFACTORY_DOCKER_BUILD_NAME% --build-number=%ARTIFACTORY_DOCKER_BUILD_NUMBER%]]></param>
+                    <param name="teamcity.step.mode" value="default" />
+                    <param name="use.custom.script" value="true" />
+                </parameters>
+            </runner>
+        </build-runners>
+        <requirements />
+    </settings>
+</meta-runner>


### PR DESCRIPTION
Since a solution for supporting multiple Docker images in a single component has not yet been implemented, this meta-runner will be used as a temporary solution for publishing Docker images.