### PR TITLE
Change the validation of the user parameter

### DIFF
--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryCommand.kt
@@ -36,12 +36,12 @@ class ArtifactoryCommand : CliktCommand(name = "") {
         val client: ArtifactoryClient = ArtifactoryClassicClient(object : ClientParametersProvider {
             override fun getApiUrl() = url
             override fun getAuth(): CredentialProvider =
-                token?.takeIf { it.isNotEmpty() }?.let { t -> StandardBearerTokenCredentialProvider(t) }
+                token?.takeIf { it.isNotBlank() }?.let { t -> StandardBearerTokenCredentialProvider(t) }
                     ?: user?.let { u -> password?.let { p -> StandardBasicCredCredentialProvider(u, p) } }
                     ?: throw IllegalArgumentException("Artifactory credentials not found")
         })
 
-        val resultUser = token?.takeIf { it.isNotEmpty() }?.let { client.getTokens().tokens.map { t -> t.subject.substringAfterLast("/") } }
+        val resultUser = token?.takeIf { it.isNotBlank() }?.let { client.getTokens().tokens.map { t -> t.subject.substringAfterLast("/") } }
             ?.firstOrNull { it.isNotBlank() }
             ?: user
             ?: throw IllegalStateException("Artifactory user not found")

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -34,6 +34,7 @@ class ApplicationTest {
         const val ARTIFACTORY_PASSWORD = "password"
 
         val ARTIFACTORY_OPTIONS = arrayOf(
+            "${ArtifactoryCommand.TOKEN_OPTION}=",
             "${ArtifactoryCommand.URL_OPTION}=$ARTIFACTORY_URL",
             "${ArtifactoryCommand.USER_OPTION}=$ARTIFACTORY_USER",
             "${ArtifactoryCommand.PASSWORD_OPTION}=$ARTIFACTORY_PASSWORD"


### PR DESCRIPTION
If the token parameter is null or empty, the user field must not be empty.