### PR TITLE
Migrate tests to OKD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,11 @@
 import com.avast.gradle.dockercompose.ComposeExtension
 import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.octopusden.octopus.task.ConfigureMockServer
+import java.net.InetAddress
+import java.util.zip.CRC32
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -11,16 +14,28 @@ plugins {
     id("com.avast.gradle.docker-compose")
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin")
+    id("org.octopusden.octopus.oc-template")
     signing
+}
+
+val defaultVersion = "${
+    with(CRC32()) {
+        update(InetAddress.getLocalHost().hostName.toByteArray())
+        value
+    }
+}-snapshot"
+
+if (version == "unspecified") {
+    version = defaultVersion
 }
 
 group = "org.octopusden.octopus.automation.artifactory"
 description = "Octopus Artifactory Automation"
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        suppressWarnings = true
-        jvmTarget = "1.8"
+    compilerOptions {
+        suppressWarnings.set(true)
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 
@@ -30,14 +45,30 @@ repositories {
     mavenCentral()
 }
 
-tasks.withType<Test> {
-    dependsOn("configureMockServer")
-    useJUnitPlatform()
-    testLogging {
-        info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+ext {
+    System.getenv().let {
+        set("signingRequired", it.containsKey("ORG_GRADLE_PROJECT_signingKey") && it.containsKey("ORG_GRADLE_PROJECT_signingPassword"))
+        set("testPlatform", it.getOrDefault("TEST_PLATFORM", properties["test.platform"]))
+        set("dockerRegistry", it.getOrDefault("DOCKER_REGISTRY", properties["docker.registry"]))
+        set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]))
+        set("okdActiveDeadlineSeconds", it.getOrDefault("OKD_ACTIVE_DEADLINE_SECONDS", properties["okd.active-deadline-seconds"]))
+        set("okdProject", it.getOrDefault("OKD_PROJECT", properties["okd.project"]))
+        set("okdClusterDomain", it.getOrDefault("OKD_CLUSTER_DOMAIN", properties["okd.cluster-domain"]))
+        set("okdWebConsoleUrl", (it.getOrDefault("OKD_WEB_CONSOLE_URL", properties["okd.web-console-url"]) as String).trimEnd('/'))
+        set("mockServerVersion", it.getOrDefault("MOCK_SERVER_VERSION", properties["mock-server.version"]))
     }
-    systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
 }
+val supportedTestPlatforms = listOf("docker", "okd")
+if (project.ext["testPlatform"] !in supportedTestPlatforms) {
+    throw IllegalArgumentException("Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM")
+}
+val mandatoryProperties = mutableListOf("dockerRegistry", "octopusGithubDockerRegistry")
+if (project.ext["testPlatform"] == "okd") {
+    mandatoryProperties.add("okdActiveDeadlineSeconds")
+    mandatoryProperties.add("okdProject")
+    mandatoryProperties.add("okdClusterDomain")
+}
+fun String.getExt() = project.ext[this].toString()
 
 configure<ComposeExtension> {
     useComposeFiles.add(layout.projectDirectory.file("docker/docker-compose.yml").asFile.path)
@@ -45,18 +76,74 @@ configure<ComposeExtension> {
     captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
     environment.putAll(
         mapOf(
-            "DOCKER_REGISTRY" to properties["docker.registry"],
-            "MOCK_SERVER_VERSION" to properties["mock-server.version"],
+            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
+            "MOCK_SERVER_VERSION" to "mockServerVersion".getExt(),
         )
     )
+}
+
+ocTemplate {
+    workDir.set(layout.buildDirectory.dir("okd"))
+    clusterDomain.set("okdClusterDomain".getExt())
+    namespace.set("okdProject".getExt())
+    prefix.set("a-automation")
+    projectVersion.set(defaultVersion)
+
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+        webConsoleUrl.set(it)
+    }
+
+    service("mockserver") {
+        templateFile.set(rootProject.layout.projectDirectory.file("okd/mockserver.yaml"))
+        parameters.set(mapOf(
+            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
+            "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+            "MOCK_SERVER_VERSION" to "mockServerVersion".getExt()
+        ))
+    }
 }
 
 tasks {
     val configureMockServer by registering(ConfigureMockServer::class)
 }
 
-tasks.named("configureMockServer") {
-    dependsOn("composeUp")
+when ("testPlatform".getExt()) {
+    "okd" -> {
+        tasks.named<ConfigureMockServer>("configureMockServer") {
+            host.set(ocTemplate.getOkdHost("mockserver"))
+            port.set(80)
+            dependsOn("ocCreate")
+        }
+        tasks.withType<Test> {
+            systemProperties["test.mockserver-host"] = ocTemplate.getOkdHost("mockserver")
+            systemProperties["test.mockserver-port"] = 80
+            dependsOn("configureMockServer", "shadowJar")
+            useJUnitPlatform()
+            testLogging {
+                info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+            }
+            systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
+            finalizedBy( "ocLogs", "ocDelete")
+        }
+    }
+    "docker" -> {
+        tasks.named<ConfigureMockServer>("configureMockServer") {
+            host.set("localhost")
+            port.set(1080)
+            dependsOn("composeUp")
+        }
+        tasks.withType<Test> {
+            dependsOn("configureMockServer", "shadowJar")
+            systemProperties["test.mockserver-host"] = "localhost"
+            systemProperties["test.mockserver-port"] = "1080"
+            useJUnitPlatform()
+            testLogging {
+                info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+            }
+            systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
+            finalizedBy("composeLogs", "composeDown")
+        }
+    }
 }
 
 dependencies {
@@ -152,8 +239,7 @@ publishing {
 }
 
 signing {
-    isRequired = System.getenv().containsKey("ORG_GRADLE_PROJECT_signingKey") && System.getenv()
-        .containsKey("ORG_GRADLE_PROJECT_signingPassword")
+    isRequired = "signingRequired".getExt().toBooleanStrict()
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import com.avast.gradle.dockercompose.ComposeExtension
 import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.octopusden.octopus.task.ConfigureMockServer
 import java.net.InetAddress
 import java.util.zip.CRC32
@@ -32,11 +31,8 @@ if (version == "unspecified") {
 group = "org.octopusden.octopus.automation.artifactory"
 description = "Octopus Artifactory Automation"
 
-tasks.withType<KotlinCompile>().configureEach {
-    compilerOptions {
-        suppressWarnings.set(true)
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
+kotlin {
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
 }
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -86,7 +82,7 @@ ocTemplate {
     workDir.set(layout.buildDirectory.dir("okd"))
     clusterDomain.set("okdClusterDomain".getExt())
     namespace.set("okdProject".getExt())
-    prefix.set("a-automation")
+    prefix.set("art-auto")
     projectVersion.set(defaultVersion)
 
     "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{

--- a/buildSrc/src/main/kotlin/org/octopusden/octopus/task/ConfigureMockServer.kt
+++ b/buildSrc/src/main/kotlin/org/octopusden/octopus/task/ConfigureMockServer.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Property
 import org.mockserver.client.MockServerClient
 import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
@@ -14,10 +16,12 @@ import org.octopusden.octopus.infrastructure.artifactory.client.dto.PromoteDocke
 
 
 abstract class ConfigureMockServer : DefaultTask() {
-    private val mockServerClient = MockServerClient("localhost", 1080)
+    @get:Input abstract val host: Property<String>
+    @get:Input abstract val port: Property<Int>
 
     @TaskAction
     fun configureMockServer() {
+        val mockServerClient = MockServerClient(host.get(), port.get())
         mockServerClient.reset()
 
         mockServerClient.`when`(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,11 @@
-version=2.0-SNAPSHOT
 artifactory-client.version=2.0.62
 junit.version=5.9.2
 mock-server.version=5.15.0
+octopus-oc-template.version=2.0.4
+
 docker.registry=registry.hub.docker.com
+test.platform=docker
+okd.active-deadline-seconds=1800
+okd.project=
+okd.cluster-domain=
+okd.web-console-url=

--- a/okd/mockserver.yaml
+++ b/okd/mockserver.yaml
@@ -1,0 +1,54 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: mockserver-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-mockserver
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      containers:
+        - name: mockserver
+          image: ${DOCKER_REGISTRY}/mockserver/mockserver:mockserver-${MOCK_SERVER_VERSION}
+          ports:
+            - containerPort: 1080
+              protocol: TCP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver-service
+    spec:
+      ports:
+        - port: 1080
+          protocol: TCP
+          targetPort: 1080
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-mockserver
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver-route
+    spec:
+      port:
+        targetPort: 1080
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-mockserver-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Mockserver version
+    name: MOCK_SERVER_VERSION
+    required: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version ("8.1.1")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
+        id("org.octopusden.octopus.oc-template") version (extra["octopus-oc-template.version"] as String)
     }
 }
 

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -39,9 +39,13 @@ class ApplicationTest {
             .waitFor()
 
     companion object {
-        const val HELP_OPTION = "-h"
+        private val mockserverHost = System.getProperty("test.mockserver-host")
+            ?: throw Exception("System property 'test.mockserver-host' must be defined")
+        private val mockserverPort = System.getProperty("test.mockserver-port")
+            ?: throw Exception("System property 'test.mockserver-port' must be defined")
 
-        const val ARTIFACTORY_URL = "http://localhost:1080"
+        private val ARTIFACTORY_URL = "http://$mockserverHost:$mockserverPort"
+        const val HELP_OPTION = "-h"
         const val ARTIFACTORY_USER = "admin"
         const val ARTIFACTORY_PASSWORD = "password"
         const val ARTIFACTORY_TOKEN = "token"


### PR DESCRIPTION
The following okd parameters have also been created:
```
okd.active-deadline-seconds=1800
okd.project=
okd.cluster-domain=
okd.web-console-url=
```
