### PR TITLE
Support docker publishing with multiple container engine

### DIFF
--- a/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
+++ b/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
@@ -20,7 +20,24 @@ val dockerRegistry = "%DOCKER_REGISTRY%"
 val dockerRepository = "%ARTIFACTORY_DOCKER_REPOSITORY%"
 val buildName = "%ARTIFACTORY_DOCKER_BUILD_NAME%"
 val buildNumber = "%ARTIFACTORY_DOCKER_BUILD_NUMBER%"
-val engine = "%container.engine%"
+val containerEngineParam = "%container.engine%"
+
+// Normalize container engine: validate and prefer podman if multiple values
+val engine = containerEngineParam.split(",")
+    .map { it.trim() }
+    .filter { it.isNotEmpty() }
+    .let { engines ->
+        val validEngines = engines.filter { it == "docker" || it == "podman" }
+
+        if (validEngines.isEmpty()) {
+            throw RuntimeException("Invalid container.engine value: '\$containerEngineParam'. Must contain 'docker' or 'podman'.")
+        }
+
+        // Prefer podman if present, otherwise use docker
+        if (validEngines.contains("podman")) "podman" else validEngines.first()
+    }
+
+println("Using container engine: \$engine")
 
 val dockerImagesList = dockerImages.split(",").map { it.trim() }
 

--- a/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
+++ b/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
@@ -24,7 +24,7 @@ val containerEngineParam = "%container.engine%"
 
 // Normalize container engine: validate and prefer podman if multiple values
 val engine = containerEngineParam.split(",")
-    .map { it.trim() }
+    .map { it.trim().lowercase() }
     .filter { it.isNotEmpty() }
     .let { engines ->
         val validEngines = engines.filter { it == "docker" || it == "podman" }

--- a/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
+++ b/metarunners/ArtifactoryPushMultiDockerImagesAndPublishBuild.xml
@@ -2,74 +2,24 @@
     <description>Create and publish Artifactory build and push multi docker images to it</description>
     <settings>
         <parameters>
-            <param name="DOCKER_REGISTRY" value="%DOCKER_REGISTRY%" />
-            <param name="ARTIFACTORY_DOCKER_IMAGES" value="%DISTRIBUTION_ARTIFACTS_COORDINATES_DOCKER%" />
-            <param name="ARTIFACTORY_DOCKER_BUILD_NUMBER" value="%BUILD_VERSION%" />
-            <param name="ARTIFACTORY_DOCKER_REPOSITORY" value="%DOCKER_REPO_DEV%" />
-            <param name="ARTIFACTORY_DOCKER_BUILD_NAME" value="%ARTIFACTORY_DOCKER_BUILD_NAME%" />
+            <param name="DOCKER_REGISTRY" value="%DOCKER_REGISTRY%"
+                   spec="text description='Docker registry URL' display='normal'" />
+            <param name="ARTIFACTORY_DOCKER_IMAGES" value="%DISTRIBUTION_ARTIFACTS_COORDINATES_DOCKER%"
+                   spec="text description='Docker images to push (comma/semicolon-separated list of image:tag)' display='normal'" />
+            <param name="ARTIFACTORY_DOCKER_REPOSITORY" value="%DOCKER_REPO_DEV%"
+                   spec="text description='Artifactory Docker repository name' display='normal'" />
+            <param name="ARTIFACTORY_DOCKER_BUILD_NAME" value="%ARTIFACTORY_DOCKER_BUILD_NAME%"
+                   spec="text description='Artifactory build name' display='normal'" />
+            <param name="ARTIFACTORY_DOCKER_BUILD_NUMBER" value="%BUILD_VERSION%"
+                   spec="text description='Artifactory build number/version' display='normal'" />
+            <param name="CONTAINER_ENGINE" value="%container.engine%"
+                   spec="text description='Container engine to use (docker/podman, or comma-separated list - prefers podman)' display='normal'" />
         </parameters>
         <build-runners>
-            <runner name="" type="kotlinScript">
+            <runner name="push multi docker images and publish build" type="OctopusArtifactoryAutomation">
                 <parameters>
-                    <param name="kotlinPath" value="%teamcity.tool.kotlin.compiler.1.5.32%" />
-                    <param name="scriptContent"><![CDATA[import java.util.concurrent.TimeUnit
-
-
-val dockerImages = "%ARTIFACTORY_DOCKER_IMAGES%"
-val dockerRegistry = "%DOCKER_REGISTRY%"
-val dockerRepository = "%ARTIFACTORY_DOCKER_REPOSITORY%"
-val buildName = "%ARTIFACTORY_DOCKER_BUILD_NAME%"
-val buildNumber = "%ARTIFACTORY_DOCKER_BUILD_NUMBER%"
-val containerEngineParam = "%container.engine%"
-
-// Normalize container engine: validate and prefer podman if multiple values
-val engine = containerEngineParam.split(",")
-    .map { it.trim().lowercase() }
-    .filter { it.isNotEmpty() }
-    .let { engines ->
-        val validEngines = engines.filter { it == "docker" || it == "podman" }
-
-        if (validEngines.isEmpty()) {
-            throw RuntimeException("Invalid container.engine value: '\$containerEngineParam'. Must contain 'docker' or 'podman'.")
-        }
-
-        // Prefer podman if present, otherwise use docker
-        if (validEngines.contains("podman")) "podman" else validEngines.first()
-    }
-
-println("Using container engine: \$engine")
-
-val dockerImagesList = dockerImages.split(",").map { it.trim() }
-
-for (dockerImage in dockerImagesList) {
-    val command = "jfrog rt \$engine-push \$dockerRegistry/\$dockerImage \$dockerRepository --build-name=\$buildName --build-number=\$buildNumber"
-    println("Executing: \$command")
-
-	val process = ProcessBuilder(*command.split(" ").toTypedArray())
-        .inheritIO()
-        .start()
-
-    val success = process.waitFor(10, TimeUnit.MINUTES)
-
-    if (!success || process.exitValue() != 0) {
-        throw RuntimeException("Command failed for \$dockerImage with exit code \${process.exitValue()} and message \${process.inputStream.bufferedReader().readText()}")
-    } else {
-        println("Successfully pushed \$dockerImage")
-    }
-
-}]]></param>
-                    <param name="scriptType" value="customScript" />
-                    <param name="teamcity.step.mode" value="default" />
-                </parameters>
-            </runner>
-            <runner name="Publish Artifactory Build" type="simpleRunner">
-                <parameters>
-                    <param name="org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource" value="Job configuration" />
-                    <param name="org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource" value="Job configuration" />
-                    <param name="org.jfrog.artifactory.selectedDeployableServer.useSpecs" value="false" />
-                    <param name="script.content"><![CDATA[jfrog rt bp %ARTIFACTORY_DOCKER_BUILD_NAME% %ARTIFACTORY_DOCKER_BUILD_NUMBER%]]></param>
-                    <param name="teamcity.step.mode" value="default" />
-                    <param name="use.custom.script" value="true" />
+                    <param name="ARGS"
+                           value="--token=%ARTIFACTORY_ACCESS_TOKEN% --url=%ARTIFACTORY_URL% --user=%ARTIFACTORY_USER% --password=%ARTIFACTORY_PASSWORD% push-multi-docker-images --docker-registry=%DOCKER_REGISTRY% --docker-images=%ARTIFACTORY_DOCKER_IMAGES% --docker-repository=%ARTIFACTORY_DOCKER_REPOSITORY% --build-name=%ARTIFACTORY_DOCKER_BUILD_NAME% --build-number=%ARTIFACTORY_DOCKER_BUILD_NUMBER% --container-engine=%CONTAINER_ENGINE%"/>
                 </parameters>
             </runner>
         </build-runners>

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/Application.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/Application.kt
@@ -7,6 +7,7 @@ const val SPLIT_SYMBOLS = "[,;]"
 fun main(args: Array<String>) {
     ArtifactoryCommand().subcommands(
         ArtifactoryPromoteBuild(),
-        ArtifactoryPromoteDockerImages()
+        ArtifactoryPromoteDockerImages(),
+        ArtifactoryPushMultiDockerImagesAndPublish()
     ).main(args)
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
@@ -51,19 +51,23 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
     }
 
     private fun pushDockerImage(dockerImage: String) {
-        val command = "jfrog rt $containerEngine-push $dockerRegistry/$dockerImage $dockerRepository --build-name=$buildName --build-number=$buildNumber"
-        executeCommand(command, "Push docker image '$dockerImage'")
+        executeCommand(
+            listOf("jfrog", "rt", "$containerEngine-push", "$dockerRegistry/$dockerImage", dockerRepository, "--build-name=$buildName", "--build-number=$buildNumber"),
+            "Push docker image '$dockerImage'"
+        )
     }
 
     private fun publishBuildInfo() {
-        val command = "jfrog rt bp $buildName $buildNumber"
-        executeCommand(command, "Publish build info for '$buildName:$buildNumber'")
+        executeCommand(
+            listOf("jfrog", "rt", "bp", buildName, buildNumber),
+            "Publish build info for '$buildName:$buildNumber'"
+        )
     }
 
-    private fun executeCommand(command: String, description: String) {
+    private fun executeCommand(command: List<String>, description: String) {
         log.info("$description: $command")
 
-        val process = ProcessBuilder(*command.split(" ").toTypedArray())
+        val process = ProcessBuilder(command)
             .inheritIO()
             .start()
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
@@ -37,7 +37,7 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
 
     private val containerEngine by option(CONTAINER_ENGINE, help = "Container engine to use (docker/podman, or comma-separated list - prefers podman)")
         .convert { ContainerEngineNormalizer.normalize(it) }
-        .default(ContainerEngineNormalizer.DEFAULT_CONTAINER_ENGINE)
+        .required()
 
     private val log by lazy { context[ArtifactoryCommand.LOG] as Logger }
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
@@ -1,0 +1,92 @@
+package org.octopusden.octopus.automation.artifactory
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.options.check
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import org.octopusden.octopus.automation.artifactory.utils.ContainerEngineNormalizer
+import org.slf4j.Logger
+import java.util.concurrent.TimeUnit
+
+class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) {
+    private val context by requireObject<MutableMap<String, Any>>()
+
+    private val dockerRegistry by option(DOCKER_REGISTRY, help = "Docker registry URL")
+        .convert { it.trim() }.required()
+        .check("$DOCKER_REGISTRY is empty") { it.isNotEmpty() }
+
+    private val dockerImages by option(DOCKER_IMAGES, help = "Docker images to push (separated by comma/semicolon)")
+        .convert { imagesValue -> imagesValue.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() } }
+        .required()
+        .check("$DOCKER_IMAGES is empty") { it.isNotEmpty() }
+
+    private val dockerRepository by option(DOCKER_REPOSITORY, help = "Artifactory Docker repository")
+        .convert { it.trim() }.required()
+        .check("$DOCKER_REPOSITORY is empty") { it.isNotEmpty() }
+
+    private val buildName by option(BUILD_NAME, help = "Artifactory build name")
+        .convert { it.trim() }.required()
+        .check("$BUILD_NAME is empty") { it.isNotEmpty() }
+
+    private val buildNumber by option(BUILD_NUMBER, help = "Artifactory build number/version")
+        .convert { it.trim() }.required()
+        .check("$BUILD_NUMBER is empty") { it.isNotEmpty() }
+
+    private val containerEngine by option(CONTAINER_ENGINE, help = "Container engine to use (docker/podman, or comma-separated list - prefers podman)")
+        .convert { ContainerEngineNormalizer.normalize(it) }
+
+    private val log by lazy { context[ArtifactoryCommand.LOG] as Logger }
+
+    override fun run() {
+        log.info("Using container engine: $containerEngine")
+        log.info("Pushing ${dockerImages.size} docker image(s) to repository '$dockerRepository'")
+        for (dockerImage in dockerImages) {
+            pushDockerImage(dockerImage)
+        }
+        publishBuildInfo()
+    }
+
+    private fun pushDockerImage(dockerImage: String) {
+        val command = "jfrog rt $containerEngine-push $dockerRegistry/$dockerImage $dockerRepository --build-name=$buildName --build-number=$buildNumber"
+        executeCommand(command, "Push docker image '$dockerImage'")
+    }
+
+    private fun publishBuildInfo() {
+        val command = "jfrog rt bp $buildName $buildNumber"
+        executeCommand(command, "Publish build info for '$buildName:$buildNumber'")
+    }
+
+    private fun executeCommand(command: String, description: String) {
+        log.info("$description: $command")
+
+        val process = ProcessBuilder(*command.split(" ").toTypedArray())
+            .inheritIO()
+            .start()
+
+        val success = process.waitFor(DEFAULT_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+
+        if (!success) {
+            process.destroyForcibly()
+            throw RuntimeException("$description timed out after $DEFAULT_TIMEOUT_MINUTES minutes")
+        }
+
+        if (process.exitValue() != 0) {
+            throw RuntimeException("$description failed with exit code ${process.exitValue()}")
+        }
+
+        log.info("$description completed successfully")
+    }
+
+    companion object {
+        const val COMMAND = "push-multi-docker-images"
+        const val DOCKER_REGISTRY = "--docker-registry"
+        const val DOCKER_IMAGES = "--docker-images"
+        const val DOCKER_REPOSITORY = "--docker-repository"
+        const val BUILD_NAME = "--build-name"
+        const val BUILD_NUMBER = "--build-number"
+        const val CONTAINER_ENGINE = "--container-engine"
+        const val DEFAULT_TIMEOUT_MINUTES = 10L
+    }
+}

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import org.octopusden.octopus.automation.artifactory.utils.ContainerEngineNormalizer
@@ -36,6 +37,7 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
 
     private val containerEngine by option(CONTAINER_ENGINE, help = "Container engine to use (docker/podman, or comma-separated list - prefers podman)")
         .convert { ContainerEngineNormalizer.normalize(it) }
+        .default(ContainerEngineNormalizer.DEFAULT_CONTAINER_ENGINE)
 
     private val log by lazy { context[ArtifactoryCommand.LOG] as Logger }
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
@@ -4,6 +4,7 @@ object ContainerEngineNormalizer {
 
     const val DOCKER = "docker"
     const val PODMAN = "podman"
+    const val DEFAULT_CONTAINER_ENGINE = PODMAN
 
     private val VALID_ENGINES = setOf(DOCKER, PODMAN)
 
@@ -23,11 +24,11 @@ object ContainerEngineNormalizer {
 
         if (validEngines.isEmpty()) {
             throw IllegalArgumentException(
-                "Invalid container.engine value: '$containerEngineParam'. Must contain 'docker' or 'podman'."
+                "Invalid container.engine value: '$containerEngineParam'. Must contain '$DOCKER' or '$PODMAN'."
             )
         }
 
-        return if (validEngines.contains(PODMAN)) PODMAN else validEngines.first()
+        return if (validEngines.contains(DEFAULT_CONTAINER_ENGINE)) DEFAULT_CONTAINER_ENGINE else validEngines.first()
     }
 
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
@@ -1,0 +1,33 @@
+package org.octopusden.octopus.automation.artifactory.utils
+
+object ContainerEngineNormalizer {
+
+    const val DOCKER = "docker"
+    const val PODMAN = "podman"
+
+    private val VALID_ENGINES = setOf(DOCKER, PODMAN)
+
+    /**
+     * Normalizes the container engine parameter value.
+     *
+     * @param containerEngineParam the raw container engine parameter (may contain multiple comma-separated values)
+     * @return the normalized engine name (prefers 'podman' if present, otherwise 'docker')
+     * @throws IllegalArgumentException if no valid engine is found
+     */
+    fun normalize(containerEngineParam: String): String {
+        val engines = containerEngineParam.split(",")
+            .map { it.trim().lowercase() }
+            .filter { it.isNotEmpty() }
+
+        val validEngines = engines.filter { it in VALID_ENGINES }
+
+        if (validEngines.isEmpty()) {
+            throw IllegalArgumentException(
+                "Invalid container.engine value: '$containerEngineParam'. Must contain 'docker' or 'podman'."
+            )
+        }
+
+        return if (validEngines.contains(PODMAN)) PODMAN else validEngines.first()
+    }
+
+}

--- a/src/test/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizerTest.kt
+++ b/src/test/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizerTest.kt
@@ -1,0 +1,68 @@
+package org.octopusden.octopus.automation.artifactory.utils
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.stream.Stream
+
+class ContainerEngineNormalizerTest {
+
+    @ParameterizedTest
+    @MethodSource("validEngineInputs")
+    fun `normalize should return correct engine for valid inputs`(input: String, expected: String) {
+        Assertions.assertEquals(expected, ContainerEngineNormalizer.normalize(input))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   ", "invalid", "kubernetes", "containerd", "rkt"])
+    fun `normalize should throw exception for invalid engine`(input: String) {
+        val exception = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            ContainerEngineNormalizer.normalize(input)
+        }
+        Assertions.assertTrue(exception.message!!.contains("Invalid container.engine value"))
+    }
+
+    companion object {
+        @JvmStatic
+        private fun validEngineInputs(): Stream<Arguments> = Stream.of(
+            // Single valid engine
+            Arguments.of("docker", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("podman", ContainerEngineNormalizer.PODMAN),
+
+            // Case-insensitive
+            Arguments.of("Docker", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("DOCKER", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("Podman", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("PODMAN", ContainerEngineNormalizer.PODMAN),
+
+            // With whitespace
+            Arguments.of("  docker  ", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("  podman  ", ContainerEngineNormalizer.PODMAN),
+
+            // Multiple values - prefer podman
+            Arguments.of("docker,podman", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("podman,docker", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("docker, podman", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("podman, docker", ContainerEngineNormalizer.PODMAN),
+
+            // Multiple values with whitespace
+            Arguments.of("  docker  ,  podman  ", ContainerEngineNormalizer.PODMAN),
+
+            // Multiple docker values
+            Arguments.of("docker,docker", ContainerEngineNormalizer.DOCKER),
+
+            // Multiple podman values
+            Arguments.of("podman,podman", ContainerEngineNormalizer.PODMAN),
+
+            // Valid with invalid mixed in
+            Arguments.of("invalid,docker", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("docker,invalid", ContainerEngineNormalizer.DOCKER),
+            Arguments.of("invalid,podman", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("podman,invalid", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("invalid,docker,podman", ContainerEngineNormalizer.PODMAN),
+            Arguments.of("kubernetes,docker,containerd", ContainerEngineNormalizer.DOCKER)
+        )
+    }
+}


### PR DESCRIPTION
New agents may specify multiple values for the `container.engine` parameter (for example, `podman,docker` or `docker,podman`). If multiple values are provided, `podman` will be used as the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New command to push multiple Docker images to Artifactory and publish build info in one operation.
  * Single consolidated invocation accepting registry, image list, repository, build name/number, container engine or ARGS-style command.
  * Improved parameter labels/descriptions for registry, images, repo, build name/number and container engine.

* **Bug Fixes**
  * Better container-engine normalization and clear error when no supported engine is provided.

* **Tests**
  * Unit tests added to validate container-engine normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->