### PR TITLE
ci: adopt octopusden quality-gates (Phase 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,15 @@
-name: Gradle Build
+name: Gradle Build & UT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/artifactory/octopus-artifactory-automation/_VER_/octopus-artifactory-automation-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/artifactory/octopus-artifactory-automation/_VER_/octopus-artifactory-automation-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,29 @@
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  quality:
+    uses: ./.github/workflows/quality.yml
+    secrets: inherit
+
+  security:
+    uses: ./.github/workflows/security.yml
+    secrets: inherit
+
+  gate-merge:
+    name: gate/merge
+    needs: [ build, quality, security ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+        with:
+          needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,14 @@
+name: Quality Gates
+
+on:
+  push:
+    branches: [main]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  quality-gates:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    with:
+      java-version: '21'
+    secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quality-gates:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality { coverage { enabled = false } }),

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,4 +11,9 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: '21'
+      # Coverage is disabled for this repo (octopusQuality { coverage { enabled = false } }),
+      # so qualityCoverage is a no-op. The default coverage-command still pulls in `test`,
+      # which is wired to docker-compose/OKD infra (composeBuild -> docker-compose) that
+      # cannot run on the GitHub runner. Exclude `test` to drop that whole infra chain.
+      coverage-command: ./gradlew qualityCoverage --no-daemon --stacktrace -x test
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,19 @@
+name: Security Reports
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    with:
+      java-version: '21'
+      enable-codeql: true
+      enable-trivy: true
+      enable-dependency-check: false
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.avast.gradle.dockercompose.ComposeExtension
-import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.octopusden.octopus.task.ConfigureMockServer
+import java.time.Duration
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -12,11 +12,23 @@ plugins {
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin")
     id("org.octopusden.octopus.oc-template")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.octopusden.octopus-quality")
     signing
 }
 
 group = "org.octopusden.octopus.automation.artifactory"
 description = "Octopus Artifactory Automation"
+
+octopusQuality {
+    coverage {
+        enabled.set(false)
+    }
+    kotlin {
+        failOnViolation.set(true)
+    }
+}
 
 kotlin {
     compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
@@ -33,7 +45,10 @@ ext {
         set("signingRequired", it.containsKey("ORG_GRADLE_PROJECT_signingKey") && it.containsKey("ORG_GRADLE_PROJECT_signingPassword"))
         set("testPlatform", it.getOrDefault("TEST_PLATFORM", properties["test.platform"]))
         set("dockerRegistry", it.getOrDefault("DOCKER_REGISTRY", properties["docker.registry"]))
-        set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]))
+        set(
+            "octopusGithubDockerRegistry",
+            it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]),
+        )
         set("okdActiveDeadlineSeconds", it.getOrDefault("OKD_ACTIVE_DEADLINE_SECONDS", properties["okd.active-deadline-seconds"]))
         set("okdProject", it.getOrDefault("OKD_PROJECT", properties["okd.project"]))
         set("okdClusterDomain", it.getOrDefault("OKD_CLUSTER_DOMAIN", properties["okd.cluster-domain"]))
@@ -43,7 +58,9 @@ ext {
 }
 val supportedTestPlatforms = listOf("docker", "okd")
 if (project.ext["testPlatform"] !in supportedTestPlatforms) {
-    throw IllegalArgumentException("Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM")
+    throw IllegalArgumentException(
+        "Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM",
+    )
 }
 val mandatoryProperties = mutableListOf("dockerRegistry", "octopusGithubDockerRegistry")
 if (project.ext["testPlatform"] == "okd") {
@@ -51,17 +68,22 @@ if (project.ext["testPlatform"] == "okd") {
     mandatoryProperties.add("okdProject")
     mandatoryProperties.add("okdClusterDomain")
 }
+
 fun String.getExt() = project.ext[this].toString()
 
 configure<ComposeExtension> {
-    useComposeFiles.add(layout.projectDirectory.file("docker/docker-compose.yml").asFile.path)
+    useComposeFiles.add(
+        layout.projectDirectory
+            .file("docker/docker-compose.yml")
+            .asFile.path,
+    )
     waitForTcpPorts.set(true)
     captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
     environment.putAll(
         mapOf(
             "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
             "MOCK_SERVER_VERSION" to "mockServerVersion".getExt(),
-        )
+        ),
     )
 }
 
@@ -71,17 +93,19 @@ ocTemplate {
     namespace.set("okdProject".getExt())
     prefix.set("art-auto")
 
-    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let {
         webConsoleUrl.set(it)
     }
 
     service("mockserver") {
         templateFile.set(rootProject.layout.projectDirectory.file("okd/mockserver.yaml"))
-        parameters.set(mapOf(
-            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
-            "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
-            "MOCK_SERVER_VERSION" to "mockServerVersion".getExt()
-        ))
+        parameters.set(
+            mapOf(
+                "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
+                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+                "MOCK_SERVER_VERSION" to "mockServerVersion".getExt(),
+            ),
+        )
     }
 }
 
@@ -106,7 +130,7 @@ when ("testPlatform".getExt()) {
             }
             val jar = tasks.shadowJar.flatMap { it.archiveFile }.also { inputs.file(it) }
             systemProperties["jar"] = jar.get().asFile.absolutePath
-            finalizedBy( "ocLogs", "ocDelete")
+            finalizedBy("ocLogs", "ocDelete")
         }
     }
     "docker" -> {
@@ -170,7 +194,10 @@ configurations {
 
 val metarunners = artifacts.add(
     "distributions",
-    layout.buildDirectory.file("distributions/metarunners.zip").get().asFile
+    layout.buildDirectory
+        .file("distributions/metarunners.zip")
+        .get()
+        .asFile,
 ) {
     classifier = "metarunners"
     type = "zip"

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>TooGenericExceptionThrown:ApplicationTest.kt$ApplicationTest.Companion$throw Exception("System property 'test.mockserver-host' must be defined")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationTest.kt$ApplicationTest.Companion$throw Exception("System property 'test.mockserver-port' must be defined")</ID>
+    <ID>TooGenericExceptionThrown:ArtifactoryPushMultiDockerImagesAndPublish.kt$ArtifactoryPushMultiDockerImagesAndPublish$throw RuntimeException("$description failed with exit code ${process.exitValue()}")</ID>
+    <ID>TooGenericExceptionThrown:ArtifactoryPushMultiDockerImagesAndPublish.kt$ArtifactoryPushMultiDockerImagesAndPublish$throw RuntimeException("$description timed out after $DEFAULT_TIMEOUT_MINUTES minutes")</ID>
+    <ID>UnusedPrivateMember:ApplicationTest.kt$ApplicationTest.Companion$@JvmStatic private fun commands(): Stream&lt;Arguments></ID>
+    <ID>UnusedPrivateMember:ContainerEngineNormalizerTest.kt$ContainerEngineNormalizerTest.Companion$@JvmStatic private fun validEngineInputs(): Stream&lt;Arguments></ID>
+    <ID>UnusedPrivateProperty:ArtifactoryCommand.kt$ArtifactoryCommand.Companion$private const val AUTH_NO_CREDENTIAL_ERROR_MESSAGE = "Either username/password or token must be set"</ID>
+    <ID>UseCheckOrError:ApplicationTest.kt$ApplicationTest$throw IllegalStateException("System property 'jar' must be provided")</ID>
+    <ID>UseCheckOrError:ArtifactoryCommand.kt$ArtifactoryCommand$throw IllegalStateException("Artifactory user not found")</ID>
+    <ID>UseRequire:ContainerEngineNormalizer.kt$ContainerEngineNormalizer$throw IllegalArgumentException( "Invalid container.engine value: '$containerEngineParam'. Must contain '$DOCKER' or '$PODMAN'.", )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,11 @@ junit.version=5.9.2
 mock-server.version=5.15.0
 octopus-oc-template.version=2.0.4
 
+# Octopus quality-gates convention plugin + Kotlin linter versions (pinned via octopus-base v2.3.5)
+octopus-quality.version=2.3.5
+detektVersion=1.23.8
+ktlintGradleVersion=14.0.1
+
 docker.registry=registry.hub.docker.com
 test.platform=docker
 okd.active-deadline-seconds=1800

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ junit.version=5.9.2
 mock-server.version=5.15.0
 octopus-oc-template.version=2.0.4
 
-# Octopus quality-gates convention plugin + Kotlin linter versions (pinned via octopus-base v2.3.5)
-octopus-quality.version=2.3.5
+# Octopus quality-gates convention plugin + Kotlin linter versions (pinned via octopus-base v2.4.0)
+octopus-quality.version=2.4.0
 detektVersion=1.23.8
 ktlintGradleVersion=14.0.1
 

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,12 +2,23 @@ import java.net.InetAddress
 import java.util.zip.CRC32
 
 pluginManagement {
+    val detektVersion: String by settings
+    val ktlintGradleVersion: String by settings
+
     plugins {
         id("org.jetbrains.kotlin.jvm") version ("2.0.21")
         id("com.gradleup.shadow") version ("8.3.6")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
         id("org.octopusden.octopus.oc-template") version (extra["octopus-oc-template.version"] as String)
+        id("io.gitlab.arturbosch.detekt") version detektVersion
+        id("org.jlleitschuh.gradle.ktlint") version ktlintGradleVersion
+        id("org.octopusden.octopus-quality") version (extra["octopus-quality.version"] as String)
+    }
+
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
     }
 }
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/Application.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/Application.kt
@@ -5,9 +5,10 @@ import com.github.ajalt.clikt.core.subcommands
 const val SPLIT_SYMBOLS = "[,;]"
 
 fun main(args: Array<String>) {
-    ArtifactoryCommand().subcommands(
-        ArtifactoryPromoteBuild(),
-        ArtifactoryPromoteDockerImages(),
-        ArtifactoryPushMultiDockerImagesAndPublish()
-    ).main(args)
+    ArtifactoryCommand()
+        .subcommands(
+            ArtifactoryPromoteBuild(),
+            ArtifactoryPromoteDockerImages(),
+            ArtifactoryPushMultiDockerImagesAndPublish(),
+        ).main(args)
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryCommand.kt
@@ -16,9 +16,12 @@ import org.octopusden.octopus.infrastructure.client.commons.StandardBearerTokenC
 import org.slf4j.LoggerFactory
 
 class ArtifactoryCommand : CliktCommand(name = "") {
-    private val url by option(URL_OPTION, help = "Artifactory URL").convert { it.trim() }.required()
+    private val url by option(URL_OPTION, help = "Artifactory URL")
+        .convert { it.trim() }
+        .required()
         .check("$URL_OPTION is empty") { it.isNotEmpty() }
-    private val user by option(USER_OPTION, help = "Artifactory user").convert { it.trim() }
+    private val user by option(USER_OPTION, help = "Artifactory user")
+        .convert { it.trim() }
         .check("$USER_OPTION is empty") {
             !token.isNullOrBlank() || !it.isNullOrBlank()
         }
@@ -35,13 +38,16 @@ class ArtifactoryCommand : CliktCommand(name = "") {
         val log = LoggerFactory.getLogger(ArtifactoryCommand::class.java.`package`.name)
         val client: ArtifactoryClient = ArtifactoryClassicClient(object : ClientParametersProvider {
             override fun getApiUrl() = url
+
             override fun getAuth(): CredentialProvider =
                 token?.takeIf { it.isNotBlank() }?.let { t -> StandardBearerTokenCredentialProvider(t) }
                     ?: user?.let { u -> password?.let { p -> StandardBasicCredCredentialProvider(u, p) } }
                     ?: throw IllegalArgumentException("Artifactory credentials not found")
         })
 
-        val resultUser = token?.takeIf { it.isNotBlank() }?.let { client.getTokens().tokens.map { t -> t.subject.substringAfterLast("/") } }
+        val resultUser = token
+            ?.takeIf { it.isNotBlank() }
+            ?.let { client.getTokens().tokens.map { t -> t.subject.substringAfterLast("/") } }
             ?.firstOrNull { it.isNotBlank() }
             ?: user
             ?: throw IllegalStateException("Artifactory user not found")

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPromoteBuild.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPromoteBuild.kt
@@ -16,25 +16,31 @@ class ArtifactoryPromoteBuild : CliktCommand(name = COMMAND) {
     private val context by requireObject<MutableMap<String, Any>>()
 
     private val buildName by option(BUILD_NAME, help = "Artifactory build name")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$BUILD_NAME is empty") { it.isNotEmpty() }
 
     private val buildNumber by option(BUILD_NUMBER, help = "Artifactory build version")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$BUILD_NUMBER is empty") { it.isNotEmpty() }
 
     private val targetRepository by option(TARGET_REPOSITORY, help = "Target Artifactory repository")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$TARGET_REPOSITORY is empty") { it.isNotEmpty() }
 
     private val targetStatus by option(TARGET_STATUS, help = "Target promotion status (e.g. 'release')")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$TARGET_STATUS is empty") { it.isNotEmpty() }
 
     private val ignoreNotFound by option(IGNORE_NOT_FOUND, help = "Ignore errors when build is not found")
-        .convert { it.trim().toBoolean() }.default(true)
+        .convert { it.trim().toBoolean() }
+        .default(true)
 
-    private val force by option(FORCE, help = "Force promotion").convert { it.trim().toBoolean() }
+    private val force by option(FORCE, help = "Force promotion")
+        .convert { it.trim().toBoolean() }
         .default(false)
 
     private val client by lazy { context[ArtifactoryCommand.CLIENT] as ArtifactoryClient }
@@ -50,7 +56,9 @@ class ArtifactoryPromoteBuild : CliktCommand(name = COMMAND) {
             if (ignoreNotFound) {
                 log.info("Artifactory build '$build' is not found")
                 return
-            } else throw e
+            } else {
+                throw e
+            }
         }
         if (buildInfo.modules.isNullOrEmpty()) {
             log.warn("Artifactory build '$build' is empty (has no modules)")

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPromoteDockerImages.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPromoteDockerImages.kt
@@ -16,23 +16,36 @@ class ArtifactoryPromoteDockerImages : CliktCommand(name = COMMAND) {
     private val context by requireObject<MutableMap<String, Any>>()
 
     private val sourceRepositories by option(
-        SOURCE_REPOSITORY, help = "Source Artifactory repositories (separated by comma/semicolon)"
+        SOURCE_REPOSITORY,
+        help = "Source Artifactory repositories (separated by comma/semicolon)",
     ).convert { sources ->
-        sources.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }.toSet()
-    }.required().check("$SOURCE_REPOSITORY is empty") { it.isNotEmpty() }
+        sources
+            .split(SPLIT_SYMBOLS.toRegex())
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }.required()
+        .check("$SOURCE_REPOSITORY is empty") { it.isNotEmpty() }
 
     private val targetRepository by option(
-        TARGET_REPOSITORY, help = "Target Artifactory repository"
+        TARGET_REPOSITORY,
+        help = "Target Artifactory repository",
     ).convert { it.trim() }.required().check("$TARGET_REPOSITORY is empty") { it.isNotEmpty() }
 
     private val images by option(
-        IMAGES, help = "Docker images coordinates in PATH:TAG format (separated by comma/semicolon)"
+        IMAGES,
+        help = "Docker images coordinates in PATH:TAG format (separated by comma/semicolon)",
     ).convert { imagesValue ->
-        imagesValue.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        imagesValue
+            .split(SPLIT_SYMBOLS.toRegex())
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
     }.required()
 
     private val ignoreNotFound by option(
-        IGNORE_NOT_FOUND, help = "Ignore errors when docker image is not found"
+        IGNORE_NOT_FOUND,
+        help = "Ignore errors when docker image is not found",
     ).convert { it.trim().toBoolean() }.default(false)
 
     private val client by lazy { context[ArtifactoryCommand.CLIENT] as ArtifactoryClient }
@@ -53,7 +66,7 @@ class ArtifactoryPromoteDockerImages : CliktCommand(name = COMMAND) {
             try {
                 client.promoteDockerImage(
                     sourceRepository,
-                    PromoteDockerImageRequest(coordinates[0], coordinates[1], targetRepository)
+                    PromoteDockerImageRequest(coordinates[0], coordinates[1], targetRepository),
                 )
                 log.info("Docker image '$image' promoted from '$sourceRepository' to '$targetRepository'")
                 return
@@ -61,8 +74,11 @@ class ArtifactoryPromoteDockerImages : CliktCommand(name = COMMAND) {
             }
         }
         with("Docker image '$image' is not found in repositories $sourceRepositories") {
-            if (ignoreNotFound) log.info(this)
-            else throw NotFoundException(this)
+            if (ignoreNotFound) {
+                log.info(this)
+            } else {
+                throw NotFoundException(this)
+            }
         }
     }
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/ArtifactoryPushMultiDockerImagesAndPublish.kt
@@ -4,7 +4,6 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.convert
-import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import org.octopusden.octopus.automation.artifactory.utils.ContainerEngineNormalizer
@@ -15,7 +14,8 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
     private val context by requireObject<MutableMap<String, Any>>()
 
     private val dockerRegistry by option(DOCKER_REGISTRY, help = "Docker registry URL")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$DOCKER_REGISTRY is empty") { it.isNotEmpty() }
 
     private val dockerImages by option(DOCKER_IMAGES, help = "Docker images to push (separated by comma/semicolon)")
@@ -24,19 +24,24 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
         .check("$DOCKER_IMAGES is empty") { it.isNotEmpty() }
 
     private val dockerRepository by option(DOCKER_REPOSITORY, help = "Artifactory Docker repository")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$DOCKER_REPOSITORY is empty") { it.isNotEmpty() }
 
     private val buildName by option(BUILD_NAME, help = "Artifactory build name")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$BUILD_NAME is empty") { it.isNotEmpty() }
 
     private val buildNumber by option(BUILD_NUMBER, help = "Artifactory build number/version")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$BUILD_NUMBER is empty") { it.isNotEmpty() }
 
-    private val containerEngine by option(CONTAINER_ENGINE, help = "Container engine to use (docker/podman, or comma-separated list - prefers podman)")
-        .convert { ContainerEngineNormalizer.normalize(it) }
+    private val containerEngine by option(
+        CONTAINER_ENGINE,
+        help = "Container engine to use (docker/podman, or comma-separated list - prefers podman)",
+    ).convert { ContainerEngineNormalizer.normalize(it) }
         .required()
 
     private val log by lazy { context[ArtifactoryCommand.LOG] as Logger }
@@ -52,19 +57,30 @@ class ArtifactoryPushMultiDockerImagesAndPublish : CliktCommand(name = COMMAND) 
 
     private fun pushDockerImage(dockerImage: String) {
         executeCommand(
-            listOf("jfrog", "rt", "$containerEngine-push", "$dockerRegistry/$dockerImage", dockerRepository, "--build-name=$buildName", "--build-number=$buildNumber"),
-            "Push docker image '$dockerImage'"
+            listOf(
+                "jfrog",
+                "rt",
+                "$containerEngine-push",
+                "$dockerRegistry/$dockerImage",
+                dockerRepository,
+                "--build-name=$buildName",
+                "--build-number=$buildNumber",
+            ),
+            "Push docker image '$dockerImage'",
         )
     }
 
     private fun publishBuildInfo() {
         executeCommand(
             listOf("jfrog", "rt", "bp", buildName, buildNumber),
-            "Publish build info for '$buildName:$buildNumber'"
+            "Publish build info for '$buildName:$buildNumber'",
         )
     }
 
-    private fun executeCommand(command: List<String>, description: String) {
+    private fun executeCommand(
+        command: List<String>,
+        description: String,
+    ) {
         log.info("$description: $command")
 
         val process = ProcessBuilder(command)

--- a/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizer.kt
@@ -1,7 +1,6 @@
 package org.octopusden.octopus.automation.artifactory.utils
 
 object ContainerEngineNormalizer {
-
     const val DOCKER = "docker"
     const val PODMAN = "podman"
     const val DEFAULT_CONTAINER_ENGINE = PODMAN
@@ -16,7 +15,8 @@ object ContainerEngineNormalizer {
      * @throws IllegalArgumentException if no valid engine is found
      */
     fun normalize(containerEngineParam: String): String {
-        val engines = containerEngineParam.split(",")
+        val engines = containerEngineParam
+            .split(",")
             .map { it.trim().lowercase() }
             .filter { it.isNotEmpty() }
 
@@ -24,11 +24,10 @@ object ContainerEngineNormalizer {
 
         if (validEngines.isEmpty()) {
             throw IllegalArgumentException(
-                "Invalid container.engine value: '$containerEngineParam'. Must contain '$DOCKER' or '$PODMAN'."
+                "Invalid container.engine value: '$containerEngineParam'. Must contain '$DOCKER' or '$PODMAN'.",
             )
         }
 
         return if (validEngines.contains(DEFAULT_CONTAINER_ENGINE)) DEFAULT_CONTAINER_ENGINE else validEngines.first()
     }
-
 }

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -1,5 +1,3 @@
-import java.io.File
-import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -7,7 +5,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.octopusden.octopus.automation.artifactory.ArtifactoryCommand
 import org.octopusden.octopus.automation.artifactory.ArtifactoryPromoteBuild
 import org.octopusden.octopus.automation.artifactory.ArtifactoryPromoteDockerImages
-
+import java.io.File
+import java.util.stream.Stream
 
 class ApplicationTest {
     private val jar = System.getProperty("jar") ?: throw IllegalStateException("System property 'jar' must be provided")
@@ -17,7 +16,11 @@ class ApplicationTest {
      */
     @ParameterizedTest
     @MethodSource("commands")
-    fun parametrizedTest(name: String, expectedExitCode: Int, command: Array<String>) {
+    fun parametrizedTest(
+        name: String,
+        expectedExitCode: Int,
+        command: Array<String>,
+    ) {
         Assertions.assertEquals(expectedExitCode, execute(name, *ARTIFACTORY_OPTIONS, *command))
     }
 
@@ -26,17 +29,27 @@ class ApplicationTest {
      */
     @ParameterizedTest
     @MethodSource("commands")
-    fun parametrizedTestWithToken(name: String, expectedExitCode: Int, command: Array<String>) {
+    fun parametrizedTestWithToken(
+        name: String,
+        expectedExitCode: Int,
+        command: Array<String>,
+    ) {
         Assertions.assertEquals(expectedExitCode, execute(name, *ARTIFACTORY_OPTIONS_WITH_TOKEN, *command))
     }
 
-    private fun execute(name: String, vararg command: String) =
-        ProcessBuilder("java", "-jar", jar, *command)
-            .redirectErrorStream(true)
-            .redirectOutput(
-                File("").resolve("build").resolve("logs").resolve("$name.log").also { it.parentFile.mkdirs() })
-            .start()
-            .waitFor()
+    private fun execute(
+        name: String,
+        vararg command: String,
+    ) = ProcessBuilder("java", "-jar", jar, *command)
+        .redirectErrorStream(true)
+        .redirectOutput(
+            File("")
+                .resolve("build")
+                .resolve("logs")
+                .resolve("$name.log")
+                .also { it.parentFile.mkdirs() },
+        ).start()
+        .waitFor()
 
     companion object {
         private val mockserverHost = System.getProperty("test.mockserver-host")
@@ -54,116 +67,142 @@ class ApplicationTest {
             "${ArtifactoryCommand.TOKEN_OPTION}=",
             "${ArtifactoryCommand.URL_OPTION}=$ARTIFACTORY_URL",
             "${ArtifactoryCommand.USER_OPTION}=$ARTIFACTORY_USER",
-            "${ArtifactoryCommand.PASSWORD_OPTION}=$ARTIFACTORY_PASSWORD"
+            "${ArtifactoryCommand.PASSWORD_OPTION}=$ARTIFACTORY_PASSWORD",
         )
 
         val ARTIFACTORY_OPTIONS_WITH_TOKEN = arrayOf(
             "${ArtifactoryCommand.TOKEN_OPTION}=$ARTIFACTORY_TOKEN",
             "${ArtifactoryCommand.URL_OPTION}=$ARTIFACTORY_URL",
-            "${ArtifactoryCommand.USER_OPTION}=$ARTIFACTORY_USER"
+            "${ArtifactoryCommand.USER_OPTION}=$ARTIFACTORY_USER",
         )
 
-        //<editor-fold defaultstate="collapsed" desc="Test Data">
+        // <editor-fold defaultstate="collapsed" desc="Test Data">
         @JvmStatic
-        private fun commands(): Stream<Arguments> = Stream.of(
-
-            Arguments.of(
-                "Test help", 0, arrayOf(HELP_OPTION)
-            ),
-            Arguments.of(
-                "Test promote-build help", 0, arrayOf(ArtifactoryPromoteBuild.COMMAND, HELP_OPTION)
-            ),
-            Arguments.of(
-                "Test promote-build", 0, arrayOf(
-                    ArtifactoryPromoteBuild.COMMAND,
-                    "${ArtifactoryPromoteBuild.BUILD_NAME}=existed-build-name",
-                    "${ArtifactoryPromoteBuild.BUILD_NUMBER}=existed-build-number1",
-                    "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
-                    "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
-                    "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=false",
-                )
-            ),
-            Arguments.of(
-                "Test promote-build with not existed build", 1, arrayOf(
-                    ArtifactoryPromoteBuild.COMMAND,
-                    "${ArtifactoryPromoteBuild.BUILD_NAME}=not-existed-build-name",
-                    "${ArtifactoryPromoteBuild.BUILD_NUMBER}=not-existed-build-version",
-                    "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
-                    "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
-                    "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=false",
-                )
-            ),
-            Arguments.of(
-                "Test promote-build with not existed build with ignore-not-found", 0, arrayOf(
-                    ArtifactoryPromoteBuild.COMMAND,
-                    "${ArtifactoryPromoteBuild.BUILD_NAME}=not-existed-build-name",
-                    "${ArtifactoryPromoteBuild.BUILD_NUMBER}=not-existed-build-version",
-                    "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
-                    "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
-                    "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=true"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images help", 0, arrayOf(ArtifactoryPromoteDockerImages.COMMAND, HELP_OPTION)
-            ),
-            Arguments.of(
-                "Test promote-docker-images", 0, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images from RC to Release", 0, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository,docker-rc-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image-rc:existed-tag"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images with not existed source docker repository", 1, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=not-existed-docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images with not existed target docker repository", 1, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=not-existed-docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images with not existed docker image", 1, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=not-existed-image:existed-tag"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images with not existed docker image with ignore-not-found", 0, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=not-existed-image:existed-tag,existed-image:existed-tag",
-                    "${ArtifactoryPromoteDockerImages.IGNORE_NOT_FOUND}=true"
-                )
-            ),
-            Arguments.of(
-                "Test promote-docker-images with invalid format image coordinates", 0, arrayOf(
-                    ArtifactoryPromoteDockerImages.COMMAND,
-                    "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
-                    "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
-                    "${ArtifactoryPromoteDockerImages.IMAGES}=invalid-format-image-coordinates,existed-image:existed-tag"
-                )
+        private fun commands(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    "Test help",
+                    0,
+                    arrayOf(HELP_OPTION),
+                ),
+                Arguments.of(
+                    "Test promote-build help",
+                    0,
+                    arrayOf(ArtifactoryPromoteBuild.COMMAND, HELP_OPTION),
+                ),
+                Arguments.of(
+                    "Test promote-build",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteBuild.COMMAND,
+                        "${ArtifactoryPromoteBuild.BUILD_NAME}=existed-build-name",
+                        "${ArtifactoryPromoteBuild.BUILD_NUMBER}=existed-build-number1",
+                        "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
+                        "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
+                        "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=false",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-build with not existed build",
+                    1,
+                    arrayOf(
+                        ArtifactoryPromoteBuild.COMMAND,
+                        "${ArtifactoryPromoteBuild.BUILD_NAME}=not-existed-build-name",
+                        "${ArtifactoryPromoteBuild.BUILD_NUMBER}=not-existed-build-version",
+                        "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
+                        "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
+                        "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=false",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-build with not existed build with ignore-not-found",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteBuild.COMMAND,
+                        "${ArtifactoryPromoteBuild.BUILD_NAME}=not-existed-build-name",
+                        "${ArtifactoryPromoteBuild.BUILD_NUMBER}=not-existed-build-version",
+                        "${ArtifactoryPromoteBuild.TARGET_REPOSITORY}=release",
+                        "${ArtifactoryPromoteBuild.TARGET_STATUS}=release",
+                        "${ArtifactoryPromoteBuild.IGNORE_NOT_FOUND}=true",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images help",
+                    0,
+                    arrayOf(ArtifactoryPromoteDockerImages.COMMAND, HELP_OPTION),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images from RC to Release",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository,docker-rc-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image-rc:existed-tag",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images with not existed source docker repository",
+                    1,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=not-existed-docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images with not existed target docker repository",
+                    1,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=not-existed-docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=existed-image:existed-tag",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images with not existed docker image",
+                    1,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=not-existed-image:existed-tag",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images with not existed docker image with ignore-not-found",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=not-existed-image:existed-tag,existed-image:existed-tag",
+                        "${ArtifactoryPromoteDockerImages.IGNORE_NOT_FOUND}=true",
+                    ),
+                ),
+                Arguments.of(
+                    "Test promote-docker-images with invalid format image coordinates",
+                    0,
+                    arrayOf(
+                        ArtifactoryPromoteDockerImages.COMMAND,
+                        "${ArtifactoryPromoteDockerImages.SOURCE_REPOSITORY}=docker-dev-repository",
+                        "${ArtifactoryPromoteDockerImages.TARGET_REPOSITORY}=docker-release-repository",
+                        "${ArtifactoryPromoteDockerImages.IMAGES}=invalid-format-image-coordinates,existed-image:existed-tag",
+                    ),
+                ),
             )
-        )
-        //</editor-fold>
+        // </editor-fold>
     }
 }

--- a/src/test/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizerTest.kt
+++ b/src/test/kotlin/org/octopusden/octopus/automation/artifactory/utils/ContainerEngineNormalizerTest.kt
@@ -8,10 +8,12 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 
 class ContainerEngineNormalizerTest {
-
     @ParameterizedTest
     @MethodSource("validEngineInputs")
-    fun `normalize should return correct engine for valid inputs`(input: String, expected: String) {
+    fun `normalize should return correct engine for valid inputs`(
+        input: String,
+        expected: String,
+    ) {
         Assertions.assertEquals(expected, ContainerEngineNormalizer.normalize(input))
     }
 
@@ -26,43 +28,37 @@ class ContainerEngineNormalizerTest {
 
     companion object {
         @JvmStatic
-        private fun validEngineInputs(): Stream<Arguments> = Stream.of(
-            // Single valid engine
-            Arguments.of("docker", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("podman", ContainerEngineNormalizer.PODMAN),
-
-            // Case-insensitive
-            Arguments.of("Docker", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("DOCKER", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("Podman", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("PODMAN", ContainerEngineNormalizer.PODMAN),
-
-            // With whitespace
-            Arguments.of("  docker  ", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("  podman  ", ContainerEngineNormalizer.PODMAN),
-
-            // Multiple values - prefer podman
-            Arguments.of("docker,podman", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("podman,docker", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("docker, podman", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("podman, docker", ContainerEngineNormalizer.PODMAN),
-
-            // Multiple values with whitespace
-            Arguments.of("  docker  ,  podman  ", ContainerEngineNormalizer.PODMAN),
-
-            // Multiple docker values
-            Arguments.of("docker,docker", ContainerEngineNormalizer.DOCKER),
-
-            // Multiple podman values
-            Arguments.of("podman,podman", ContainerEngineNormalizer.PODMAN),
-
-            // Valid with invalid mixed in
-            Arguments.of("invalid,docker", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("docker,invalid", ContainerEngineNormalizer.DOCKER),
-            Arguments.of("invalid,podman", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("podman,invalid", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("invalid,docker,podman", ContainerEngineNormalizer.PODMAN),
-            Arguments.of("kubernetes,docker,containerd", ContainerEngineNormalizer.DOCKER)
-        )
+        private fun validEngineInputs(): Stream<Arguments> =
+            Stream.of(
+                // Single valid engine
+                Arguments.of("docker", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("podman", ContainerEngineNormalizer.PODMAN),
+                // Case-insensitive
+                Arguments.of("Docker", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("DOCKER", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("Podman", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("PODMAN", ContainerEngineNormalizer.PODMAN),
+                // With whitespace
+                Arguments.of("  docker  ", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("  podman  ", ContainerEngineNormalizer.PODMAN),
+                // Multiple values - prefer podman
+                Arguments.of("docker,podman", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("podman,docker", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("docker, podman", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("podman, docker", ContainerEngineNormalizer.PODMAN),
+                // Multiple values with whitespace
+                Arguments.of("  docker  ,  podman  ", ContainerEngineNormalizer.PODMAN),
+                // Multiple docker values
+                Arguments.of("docker,docker", ContainerEngineNormalizer.DOCKER),
+                // Multiple podman values
+                Arguments.of("podman,podman", ContainerEngineNormalizer.PODMAN),
+                // Valid with invalid mixed in
+                Arguments.of("invalid,docker", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("docker,invalid", ContainerEngineNormalizer.DOCKER),
+                Arguments.of("invalid,podman", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("podman,invalid", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("invalid,docker,podman", ContainerEngineNormalizer.PODMAN),
+                Arguments.of("kubernetes,docker,containerd", ContainerEngineNormalizer.DOCKER),
+            )
     }
 }


### PR DESCRIPTION
## Summary

Adopts the octopusden quality-gates convention for this repo and introduces the mandatory `gate/merge` status check.

### Workflows
- Bumped **all** `octopusden/octopus-base` reusable-workflow refs to `@v2.3.5` (build, release, check-and-register).
- Added `merge-gate.yml` (on `pull_request`): calls local `build` + `quality` + `security` reusable workflows and aggregates their results into a single `gate/merge` check via `octopusden/octopus-base/.github/actions/merge-gate@v2.3.5`.
- Reshaped `build.yml`, `quality.yml`, `security.yml` to the canonical ORMS shape — `push: [main]` + `workflow_call` + `workflow_dispatch` (security also keeps a weekly `schedule`), **no direct `pull_request`** trigger. `build.yml` uses `flow-type: hybrid`.

### Quality plugin
- Applied `org.octopusden.octopus-quality` (pinned **2.3.5**) plus `detekt` + `ktlint` at the root (single-module Kotlin repo); tool/plugin versions declared in `settings.gradle.kts` `pluginManagement` (versions in `gradle.properties`), with `mavenCentral()` added to plugin repositories.
- `octopusQuality { coverage { enabled = false }; kotlin { failOnViolation = true } }`.

### Baselines & formatting
- Ran `ktlintFormat` (pure formatting: trailing commas, line wrapping, EOF newlines — no semantic changes).
- Committed `detekt-baseline.xml` (10 entries) and `ktlint-baseline.xml` (empty after format).
- ktlint baseline: **194 → 0** entries after `ktlintFormat`.

### Local verification
- `./gradlew qualityStatic` runs `:detekt` and `:ktlintCheck` (all source sets) and passes **green** with `failOnViolation=true` — the gate is **non-hollow** (actually scans Kotlin). Verified locally against Maven Central (corporate mirror unreachable from sandbox); GitHub Actions resolves dependencies normally, so CI is the authoritative gate.

Do not merge; no assignees/reviewers added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)